### PR TITLE
Reset label value on upload

### DIFF
--- a/bear_classifier.ipynb
+++ b/bear_classifier.ipynb
@@ -45,7 +45,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def on_click(change):\n",
+    "def on_data_change(change):\n",
+    "    lbl_pred.value = ''\n",
     "    img = PILImage.create(btn_upload.data[-1])\n",
     "    out_pl.clear_output()\n",
     "    with out_pl: display(img.to_thumb(128,128))\n",
@@ -59,7 +60,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "btn_upload.observe(on_click, names=['data'])"
+    "btn_upload.observe(on_data_change, names=['data'])"
    ]
   },
   {


### PR DESCRIPTION
The label was not being reset when uploading a second image.

This caused the previous result to be displayed while the new one was being computed.