### PR TITLE
Pin some requirements so that Binder / voila rendering works (late 2021)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # bear_voila
 
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/shuane/bear_voila/master?urlpath=%2Fvoila%2Frender%2Fbear_classifier.ipynb)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/fastai/bear_voila/master?urlpath=%2Fvoila%2Frender%2Fbear_classifier.ipynb)
 
 Demo bear classifier with fastai and Voila

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # bear_voila
 
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/fastai/bear_voila/master?urlpath=%2Fvoila%2Frender%2Fbear_classifier.ipynb)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/shuane/bear_voila/master?urlpath=%2Fvoila%2Frender%2Fbear_classifier.ipynb)
 
 Demo bear classifier with fastai and Voila

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ fastcore==1.0.0
 pillow<7
 packaging
 ipywidgets==7.5.1
+torch==1.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 voila
-fastai>=2
+fastai>=2,<=2.0.6
+fastcore==1.0.0
 pillow<7
 packaging
 ipywidgets==7.5.1


### PR DESCRIPTION
Hello! I noticed that the Binder wasn't working... after some digging I found that several app versions have advanced so much that the export.pkl here could not run. 

To support the old pkl, I went back and found the versions of fastai, fastcore, and torch, at the time that the pkl was created.

This does not help with running on Windows, but it does help with Linux which in turn helps with mybinder.org...

Running version can be seen at https://mybinder.org/v2/gh/shuane/bear_voila/master?urlpath=%2Fvoila%2Frender%2Fbear_classifier.ipynb